### PR TITLE
Allow specification classes relative to (and hence distinct from) their parent module name

### DIFF
--- a/pycaliper/pycmanager.py
+++ b/pycaliper/pycmanager.py
@@ -229,12 +229,20 @@ def create_module(specc, args):
         sys.path.append(module_path)
 
         try:
-            # Import the module using importlib
-            module = importlib.import_module(module_name)
-            logger.debug(
-                f"Successfully imported module: {module_name} from {module_path}"
-            )
-            return getattr(module, module_name)(**params)
+            if "." in module_name:
+                module_name, class_name = module_name.rsplit(".", 1)
+                module = importlib.import_module(module_name)
+                logger.debug(
+                    f"Successfully imported module: {module_name} from {module_path}"
+                )
+                return getattr(module, class_name)(**params)
+            else:
+                # Import the module using importlib
+                module = importlib.import_module(module_name)
+                logger.debug(
+                    f"Successfully imported module: {module_name} from {module_path}"
+                )
+                return getattr(module, module_name)(**params)
         except ImportError as e:
             logger.error(
                 f"Error importing module {module_name} from {module_path}: {e}"


### PR DESCRIPTION
In the `config.json` file, allow specification paths of form: 
1. `path/file`, which is a specification generated from class `file` in file `path/file.py`. Here `path` is a standard "`/`" separated file path, and `file` is a string without `/` or `.`.
2. `path/file.classname`, which is a specification from class `classname` in file `path.py`. Here `path` is a standard "`/`" separated file path.
3. _will be deprecated_: `spec`: which is a specification generated from the class `spec` in file `specs/spec.py` (in default `specs` directory)
